### PR TITLE
Fix audio class render function call in constructor

### DIFF
--- a/app/assets/javascripts/avalon/app.js
+++ b/app/assets/javascripts/avalon/app.js
@@ -5,7 +5,6 @@ Avalon = {
     }
     if ($('[data-iiifav-audio-source]').length > 0) {
       this.mediaPlayerAudio()
-      origin/feature-play-audio
     }
   },
 

--- a/app/assets/javascripts/avalon/audio-player.es6
+++ b/app/assets/javascripts/avalon/audio-player.es6
@@ -1,11 +1,12 @@
 import MediaPlayer from 'avalon/media-player'
 
 export default class AudioPlayer extends MediaPlayer {
-   constructor(options) {
-        super(options)
-        this.render()
-   }
-      // Audio player configurations
+  constructor (options) {
+    super(options)
+    this.render(options)
+  }
+
+  // Audio player configurations
   getAudioConfig () {
     return {
       audioHeight: this.manifest.height || 200,
@@ -22,14 +23,17 @@ export default class AudioPlayer extends MediaPlayer {
     })
     return audioItems
   }
-    render (audio) {
+
+  render (options = { audio: {} }) {
     // Assume for now only one audio item, with different quality files
     let audioItems = this.getAudioItems()
-    if (!audio.quality) { audio.quality = 'Medium' }
+
+    options.audio = options.audio || {}
+    options.audio.quality = options.audio.quality || 'Medium'
 
     if (audioItems.length > 0) {
       audioItems.forEach((item) => {
-        if (item.label === audio.quality) {
+        if (item.label === options.audio.quality) {
           const audioElement = `<audio controls id="iiif-av-audio-player">
             <source src="${item.id}" type="audio/mp3" data-quality="${item.label}">
           </audio>`


### PR DESCRIPTION
Added the options argument to render(options) in the Audio class constructor function.  Audio player and tests work again.